### PR TITLE
Add RepeatedAppraisalStepsValidator and tests

### DIFF
--- a/src/CrystallineSociety/Shared/CrystallineSociety.Shared.Test/BadgeSystem/BadgeSystemValidationTests.cs
+++ b/src/CrystallineSociety/Shared/CrystallineSociety.Shared.Test/BadgeSystem/BadgeSystemValidationTests.cs
@@ -13,6 +13,184 @@ public class BadgeSystemValidationTests : TestBase
     public TestContext TestContext { get; set; } = default!;
 
     [TestMethod]
+    public void RepeatedAppraisalMethodValidator_NoErrors()
+    {
+        var badge1 = """
+                    {
+                      "code": "doc-guru",
+                      "description": "Description for doc-guru",
+                      "level": "Gold",
+                      "appraisal-methods": [
+                        {
+                          "title": "Main Method",
+                          "activity-requirements": [
+                            "requirement-activity-code-A",
+                            "requirement-activity-code-B:1",
+                            "requirement-activity-code-C|requirement-activity-code-D:2"
+                          ],
+
+                        "approving-steps": [
+                            {
+                              "step": 1,
+                              "title": "First Approval",
+                              "approver-required-badges": [
+                                "doc-guru"
+                              ],
+                              "required-approval-count": 4
+                            },
+                            {
+                              "step": 2,
+                              "title": "Last Approval",
+                              "approver-required-badges": [
+                                "doc-guru"
+                              ],
+                              "required-approval-count": 3 
+                            }
+                          ]
+                        }
+                      ]
+                    }      
+                    """;
+        var badgeSystem = CreateBadgeSystem(new[] { badge1 });
+
+        Assert.IsNotNull(badgeSystem.Validations);
+        Assert.AreEqual(
+            0,
+            badgeSystem.Errors.Count());
+    }
+
+    [TestMethod]
+    public void
+       RepeatedAppraisalMethodValidator_BadgeBundleContainingSingleInvalidBadge_ListOfErrorsForTheBadgeWithRepeatedTitlesInTheirAppraisalMethod()
+    {
+        var badge1 = """
+                    {
+                      "code": "doc-guru",
+                      "description": "Description for doc-guru",
+                      "level": "Gold",
+                      "appraisal-methods": [
+                        {
+                          "title": "Main Method",
+                          "activity-requirements": [
+                            "requirement-activity-code-A",
+                            "requirement-activity-code-B:1",
+                            "requirement-activity-code-C|requirement-activity-code-D:2"
+                          ]
+                          
+                        },
+                        {
+                          "title": "Main Method",
+                          "activity-requirements": [
+                            "requirement-activity-code-A",
+                            "requirement-activity-code-B:1",
+                            "requirement-activity-code-C|requirement-activity-code-D:2"
+                          ]
+                          
+                        }
+                      ]
+                   
+                    }      
+                    """;
+
+
+        var badgeSystem = CreateBadgeSystem(new[] { badge1 });
+
+        Assert.IsNotNull(badgeSystem.Validations);
+        Assert.AreEqual(
+            1,
+            badgeSystem.Errors.Count(e =>
+                e.Title.Equals(
+                    "Repeated appraisal method: Main Method")));
+
+        Assert.AreEqual("Main Method", badgeSystem.Errors.Find(t => t.Title.Equals("Repeated appraisal method: Main Method")).RefBadge);
+
+        Assert.AreEqual(
+            "Main Method", badgeSystem.Errors.Find(t =>
+                    t.Title.Equals(
+                        "Repeated appraisal method: Main Method"))
+                .RefBadge);
+    }
+
+    [TestMethod]
+    public void
+       RepeatedAppraisalMethodValidator_BadgeBundleContainingMultipleInvalidBadge_ListOfErrorsForTheBadgeWithRepeatedTitlesInTheirAppraisalMethod()
+    {
+        var badge1 = """
+                    {
+                      "code": "doc-guru",
+                      "description": "Description for doc-guru",
+                      "level": "Gold",
+                      "appraisal-methods": [
+                        {
+                          "title": "Main Method",
+                          "activity-requirements": [
+                            "requirement-activity-code-A",
+                            "requirement-activity-code-B:1",
+                            "requirement-activity-code-C|requirement-activity-code-D:2"
+                          ]
+                          
+                        },
+                        {
+                          "title": "Main Method",
+                          "activity-requirements": [
+                            "requirement-activity-code-A",
+                            "requirement-activity-code-B:1",
+                            "requirement-activity-code-C|requirement-activity-code-D:2"
+                          ]
+                          
+                        }
+                      ]
+                   
+                    }      
+                    """;
+
+        var badge2 = """
+                    {
+                      "code": "doc-guru",
+                      "description": "Description for doc-guru",
+                      "level": "Gold",
+                      "appraisal-methods": [
+                        {
+                          "title": "Main Method",
+                          "activity-requirements": [
+                            "requirement-activity-code-A",
+                            "requirement-activity-code-B:1",
+                            "requirement-activity-code-C|requirement-activity-code-D:2"
+                          ]
+                          
+                        },
+                        {
+                          "title": "Main Method",
+                          "activity-requirements": [
+                            "requirement-activity-code-A",
+                            "requirement-activity-code-B:1",
+                            "requirement-activity-code-C|requirement-activity-code-D:2"
+                          ]
+                          
+                        }
+                      ]
+                   
+                    }      
+                    """;
+
+        var badgeSystem = CreateBadgeSystem(new[] { badge1, badge2 });
+
+        Assert.IsNotNull(badgeSystem.Validations);
+        Assert.AreEqual(
+            2,
+            badgeSystem.Errors.Count(e =>
+                e.Title.Equals(
+                    "Repeated appraisal method: Main Method")));
+
+        Assert.AreEqual("Main Method", badgeSystem.Errors.Find(t => t.Title.Equals("Repeated appraisal method: Main Method")).RefBadge);
+
+        Assert.AreEqual(
+            "Main Method", badgeSystem.Errors.Find(t =>
+                    t.Title.Equals(
+                        "Repeated appraisal method: Main Method"))
+                .RefBadge);
+    }
+    [TestMethod]
     public void RepeatedApprovingStepsValidator_BadgeBundleContainingSingleValidBadge_NoErrors()
     {
         var badge1 = """

--- a/src/CrystallineSociety/Shared/Shared/Extensions/IServiceCollectionExtensions.cs
+++ b/src/CrystallineSociety/Shared/Shared/Extensions/IServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ public static class IServiceCollectionExtensions
         services.AddTransient<IBadgeSystemValidator, BadgeMustHaveValidNameValidator>();
         services.AddTransient<IBadgeSystemValidator, RepeatDependencyValidator>();
         services.AddTransient<IBadgeSystemValidator, RepeatedApprovingStepsValidator>();
+        services.AddTransient<IBadgeSystemValidator, RepeatedAppraisalMethodValidator>();
         services.AddSingleton<AppStateDto, AppStateDto>();
     }
 

--- a/src/CrystallineSociety/Shared/Shared/Services/Implementations/BadgeSystem/Validations/RepeatedAppraisalMethodValidator.cs
+++ b/src/CrystallineSociety/Shared/Shared/Services/Implementations/BadgeSystem/Validations/RepeatedAppraisalMethodValidator.cs
@@ -1,0 +1,44 @@
+﻿using CrystallineSociety.Shared.Dtos.BadgeSystem;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CrystallineSociety.Shared.Services.Implementations.BadgeSystem.Validations
+{
+    public class RepeatedAppraisalMethodValidator: BadgeSystemValidator
+    {
+        public override List<BadgeSystemValidationDto> ValidateBundle(BadgeBundleDto badgeBundle)
+        {
+            var repeatedAppraisalMethods = GetRepeatedAppraisalMethods(badgeBundle);
+
+            return repeatedAppraisalMethods.Select(repeatedItem =>
+                               BadgeSystemValidationDto.Error($"Repeated appraisal method: {repeatedItem}",
+                                                      $"Appraisal methods should be unique",
+                                                                             refBadge: repeatedItem))
+                .ToList();
+        }
+
+        private static IEnumerable<string> GetRepeatedAppraisalMethods(BadgeBundleDto badgeBundle)
+        {
+            var appraisalMethods = new List<string>();
+
+            foreach (var badge in badgeBundle.Badges)
+            {
+                if (badge.AppraisalMethods == null)
+                    continue;
+
+                var repeatedItems = badge.AppraisalMethods
+                    .GroupBy(x => x.Title)
+                    .Where(g => g.Count() > 1)
+                    .Select(g => g.Key)
+                    .ToList();
+
+                repeatedItems.ForEach(x => appraisalMethods.Add(x));
+            }
+
+            return appraisalMethods;
+        }
+    }
+}


### PR DESCRIPTION
I added the following unit tests to the Badge class, as well as the RepeatedAppraisalMethodValidator service to the interface. Finally, I added the RepeatedAppraisalMethodValidator class and tested the unit tests. All of them passed. Additionally, I created new JSON samples for the unit tests.

List of unit tests added to the Unit class BadgeSystemValidationTests

1. RepeatedAppraisalMethodValidator_NoErrors
2.RepeatedAppraisalMethodValidator_BadgeBundleContainingSingleInvalidBadge_ListOfErrorsForTheBadgeWithRepeatedTitlesInTheirAppraisalMethod
3.RepeatedAppraisalMethodValidator_BadgeBundleContainingMultipleInvalidBadge_ListOfErrorsForTheBadgeWithRepeatedTitlesInTheirAppraisalMethod