### PR TITLE
Update .NET SDK installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ Before you can run a .NET application, you need to install the .NET SDK. To inst
 - Click on the download link and run the installer.
 - Follow the instructions in the installer.
 
-You can verify the installation by opening a new command prompt or terminal window and running the command `dotnet --version`. This should display the version of the .NET SDK that you installed. If you installed it correctly, it should show a version number starting with `7.0`.
-
-You can verify the installation by opening a new command prompt or terminal window and running the command `dotnet --version`. This should display the version of the .NET SDK that you installed.
+You can verify the installation by opening a new command prompt or terminal window and running the command `dotnet --version`. This should display the version of the .NET SDK that you installed. If you installed it correctly, it should show a version number starting with `7.X.X`.
 
 ### Development Environment
 You have the flexibility to develop this project using one of the recommended IDEs below, or feel free to use your preferred IDE:


### PR DESCRIPTION
The most significant change is the update to the instructions for verifying the installation of the .NET SDK. The instructions now state that a successful installation will display a version number starting with `7.X.X`, allowing for minor version updates within the `7.X` major version.

List of Changes:

1.  Updated the instructions for verifying the .NET SDK installation. The instructions now specify that a successful installation will display a version number starting with `7.X.X`, accommodating minor version updates within the `7.X` major version.

References to the code changes are not provided in the original text.