### PR TITLE
Refactor sync loop and update job schedule to hourly

### DIFF
--- a/src/Core/CrystaLearn.Core/Services/Jobs/CrystaProgramSyncJobRunner.cs
+++ b/src/Core/CrystaLearn.Core/Services/Jobs/CrystaProgramSyncJobRunner.cs
@@ -25,9 +25,11 @@ public partial class CrystaProgramSyncJobRunner
             isRunning = true;
             var modules = await syncModuleService.GetSyncModulesAsync(cancellationToken);
 
-            foreach (var module in modules)
+            int i = 0;
+            while (i < modules.Count)
             {
-                await syncService.SyncAsync(module);
+                await syncService.SyncAsync(modules[i]);
+                i++;
             }
         }
         catch (Exception ex)

--- a/src/Server/CrystaLearn.Server.Api/Program.Middlewares.cs
+++ b/src/Server/CrystaLearn.Server.Api/Program.Middlewares.cs
@@ -83,6 +83,6 @@ public static partial class Program
         RecurringJob.AddOrUpdate<CrystaLearn.Core.Services.Jobs.CrystaProgramSyncJobRunner>(
             recurringJobId: "crysta-program-sync",
             methodCall: x => x.RunSyncForAllModules(CancellationToken.None),
-            cronExpression: "*/1 * * * *");
+            cronExpression: "0 */1 * * *");
     }
 }

--- a/src/Server/CrystaLearn.Server.Web/Program.Middlewares.cs
+++ b/src/Server/CrystaLearn.Server.Web/Program.Middlewares.cs
@@ -167,7 +167,7 @@ public static partial class Program
         RecurringJob.AddOrUpdate<CrystaLearn.Core.Services.Jobs.CrystaProgramSyncJobRunner>(
             recurringJobId: "crysta-program-sync",
             methodCall: x => x.RunSyncForAllModules(CancellationToken.None),
-            cronExpression: "*/1 * * * *");
+            cronExpression: "0 */1 * * *");
     }
 
     /// <summary>


### PR DESCRIPTION
Refactored CrystaProgramSyncJobRunner to use a while loop with index-based access instead of foreach for module iteration. Updated the Hangfire recurring job schedule for "crysta-program-sync" to run at the start of every hour instead of every minute.