### PR TITLE
#108 Refactor CrystaTask to service interface; add test fakes

### DIFF
--- a/src/Core/CrystaLearn.Core.Test/Sync/AzureBoardSyncServiceTests.cs
+++ b/src/Core/CrystaLearn.Core.Test/Sync/AzureBoardSyncServiceTests.cs
@@ -20,7 +20,8 @@ public class AzureBoardSyncServiceTests : TestBase
         // Arrange
         var services = CreateServiceProvider(configServices: (sc) =>
         {
-            sc.AddTransient<ICrystaProgramSyncModuleService, CrystaProgramSyncModuleService>();
+            sc.AddTransient<ICrystaProgramSyncModuleService, CrystaProgramSyncModuleServiceFake>();
+            sc.AddTransient<ICrystaTaskService, CrystaTaskServiceFake>();
         });
 
         using var scope = services.CreateScope();
@@ -63,7 +64,8 @@ public class AzureBoardSyncServiceTests : TestBase
         // Arrange
         var services = CreateServiceProvider(configServices: (sc) =>
         {
-            sc.AddTransient<ICrystaProgramSyncModuleService, CrystaProgramSyncModuleService>();
+            sc.AddTransient<ICrystaProgramSyncModuleService, CrystaProgramSyncModuleServiceFake>();
+            sc.AddTransient<ICrystaTaskService, CrystaTaskServiceFake>();
         });
 
         using var scope = services.CreateScope();
@@ -84,7 +86,8 @@ public class AzureBoardSyncServiceTests : TestBase
         // Arrange
         var services = CreateServiceProvider(configServices: (sc) =>
         {
-            sc.AddTransient<ICrystaProgramSyncModuleService, CrystaProgramSyncModuleService>();
+            sc.AddTransient<ICrystaProgramSyncModuleService, CrystaProgramSyncModuleServiceFake>();
+            sc.AddTransient<ICrystaTaskService, CrystaTaskServiceFake>();
         });
 
         using var scope = services.CreateScope();
@@ -100,8 +103,3 @@ public class AzureBoardSyncServiceTests : TestBase
         }
     }
 }
-
-//AzureBoardService Test
-//AzureSyncService Test
-// CrystaTaskRepository -> CrystaTaskService  -> Documented
-// 

--- a/src/Core/CrystaLearn.Core/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Core/CrystaLearn.Core/Extensions/ApplicationBuilderExtensions.cs
@@ -37,7 +37,7 @@ public static class ApplicationBuilderExtensions
         services.AddTransient<ICrystaProgramSyncService, CrystaProgramSyncService>();
         services.AddTransient<IAzureBoardSyncService, AzureBoardSyncService>();
         services.AddTransient<ICrystaProgramSyncModuleService, CrystaProgramSyncModuleService>();
-        services.AddTransient<ICrystaTaskRepository, CrystaTaskRepository>();
+        services.AddTransient<ICrystaTaskService, CrystaTaskService>();
     }
 
     private static void AddGitHubClient(this IHostApplicationBuilder builder)

--- a/src/Core/CrystaLearn.Core/Services/Contracts/ICrystaTaskService.cs
+++ b/src/Core/CrystaLearn.Core/Services/Contracts/ICrystaTaskService.cs
@@ -8,7 +8,7 @@ using CrystaLearn.Core.Services.Sync;
 
 namespace CrystaLearn.Core.Services.Contracts;
 
-public interface ICrystaTaskRepository
+public interface ICrystaTaskService
 {
     Task<List<SyncItem>> GetWorkItemSyncItemsAsync(List<string> ids);
     Task<List<SyncItem>> GetCommentsSyncItemsAsync(List<string> ids);

--- a/src/Core/CrystaLearn.Core/Services/CrystaProgramSyncModuleServiceFake.cs
+++ b/src/Core/CrystaLearn.Core/Services/CrystaProgramSyncModuleServiceFake.cs
@@ -10,10 +10,11 @@ public partial class CrystaProgramSyncModuleServiceFake : ICrystaProgramSyncModu
 {
     private static List<CrystaProgramSyncModule> _modules = new();
 
-    [AutoInject] private IConfiguration Configuration { get; set; } = default!;
+     private IConfiguration Configuration { get; set; } = default!;
 
-    public CrystaProgramSyncModuleServiceFake()
+    public CrystaProgramSyncModuleServiceFake(IConfiguration configuration)
     {
+        Configuration = configuration;
         if (_modules.Count == 0)
         {
             var pat = Configuration["AzureDevOps:PersonalAccessToken"];
@@ -26,14 +27,14 @@ public partial class CrystaProgramSyncModuleServiceFake : ICrystaProgramSyncModu
                     CrystaProgramId = CrystaProgramRepositoryFake.FakeProgramCSI.Id,
                     CrystaProgram = CrystaProgramRepositoryFake.FakeProgramCSI,
                     ModuleType = SyncModuleType.AzureBoard,
-                    SyncConfig =
-                        $$"""
-                        {   
-                            "Organization": "cs-internship",
-                            "PersonalAccessToken": "{pat}",
-                            "Project": "CS Internship Program"
-                        }
-                        """,
+                   SyncConfig =
+                          $$"""
+                            {
+                                "Organization": "cs-internship",
+                                "PersonalAccessToken": "{{pat}}",
+                                "Project": "CS Internship Program"
+                            }
+                            """,
                     SyncInfo = new SyncInfo
                     {
                         LastSyncDateTime = DateTimeOffset.Now.AddDays(-2),

--- a/src/Core/CrystaLearn.Core/Services/CrystaProgramSyncModuleServiceFake.cs
+++ b/src/Core/CrystaLearn.Core/Services/CrystaProgramSyncModuleServiceFake.cs
@@ -10,7 +10,7 @@ public partial class CrystaProgramSyncModuleServiceFake : ICrystaProgramSyncModu
 {
     private static List<CrystaProgramSyncModule> _modules = new();
 
-     private IConfiguration Configuration { get; set; } = default!;
+    private IConfiguration Configuration { get; set; } = default!;
 
     public CrystaProgramSyncModuleServiceFake(IConfiguration configuration)
     {

--- a/src/Core/CrystaLearn.Core/Services/CrystaTaskService.cs
+++ b/src/Core/CrystaLearn.Core/Services/CrystaTaskService.cs
@@ -7,7 +7,7 @@ using EFCore.BulkExtensions;
 
 namespace CrystaLearn.Core.Services;
 
-public partial class CrystaTaskRepository : ICrystaTaskRepository
+public partial class CrystaTaskService : ICrystaTaskService
 {
     [AutoInject] private AppDbContext DbContext { get; set; } = default!;
 

--- a/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
+++ b/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
@@ -176,7 +176,10 @@ public class CrystaTaskServiceFake : ICrystaTaskService
         if (comments == null) return Task.CompletedTask;
         foreach (var c in comments)
         {
-            var existing = _comments.FirstOrDefault(x => x.Id == c.Id || (!string.IsNullOrEmpty(x.Revision) && x.Revision == c.Revision));
+            var existing = _comments.FirstOrDefault(x =>
+                x.SyncInfo?.SyncId != null &&
+                c.SyncInfo?.SyncId != null &&
+                x.SyncInfo.SyncId == c.SyncInfo.SyncId);
             if (existing != null)
             {
                 // naive replace of reference properties

--- a/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
+++ b/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
@@ -246,7 +246,7 @@ public class CrystaTaskServiceFake : ICrystaTaskService
         if (updates == null) return Task.CompletedTask;
         foreach (var u in updates)
         {
-            var existing = _updates.FirstOrDefault(x => x.Id == u.Id || (!string.IsNullOrEmpty(x.Revision) && x.Revision == u.Revision));
+            var existing = _updates.FirstOrDefault(x => x.SyncInfo?.SyncId == u.SyncInfo?.SyncId);
             if (existing != null)
             {
                 var idx = _updates.IndexOf(existing);

--- a/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
+++ b/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
@@ -229,7 +229,11 @@ public class CrystaTaskServiceFake : ICrystaTaskService
         if (tasks == null) return Task.CompletedTask;
         foreach (var t in tasks)
         {
-            var existing = _tasks.FirstOrDefault(x => x.Id == t.Id || (!string.IsNullOrEmpty(x.ProviderTaskId) && x.ProviderTaskId == t.ProviderTaskId));
+            var existing = _tasks.FirstOrDefault(x =>
+                x.WorkItemSyncInfo != null && t.WorkItemSyncInfo != null &&
+                !string.IsNullOrEmpty(x.WorkItemSyncInfo.SyncId) &&
+                !string.IsNullOrEmpty(t.WorkItemSyncInfo.SyncId) &&
+                x.WorkItemSyncInfo.SyncId == t.WorkItemSyncInfo.SyncId);
             if (existing != null)
             {
                 var idx = _tasks.IndexOf(existing);

--- a/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
+++ b/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
@@ -77,7 +77,6 @@ public class CrystaTaskServiceFake : ICrystaTaskService
                 if (c.IsDeleted != true)
                 {
                     c.IsDeleted = true;
-                    c.SyncStatus = CrystaSyncStatus.Deleted;
                     marked++;
                 }
             }

--- a/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
+++ b/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
@@ -162,7 +162,7 @@ public class CrystaTaskServiceFake : ICrystaTaskService
     public Task<int> MarkCrystaTasksAsDeletedAsync(List<string> syncIds)
     {
         if (syncIds == null || syncIds.Count == 0) return Task.FromResult(0);
-        var matched = _tasks.Where(t => (t.ProviderTaskId != null && syncIds.Contains(t.ProviderTaskId)) || (t.Id != Guid.Empty && syncIds.Contains(t.Id.ToString()))).ToList();
+        var matched = _tasks.Where(t => t.WorkItemSyncInfo != null && syncIds.Contains(t.WorkItemSyncInfo.SyncId ?? "")).ToList();
         foreach (var t in matched)
         {
             t.IsDeleted = true;

--- a/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
+++ b/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
@@ -66,11 +66,24 @@ public class CrystaTaskServiceFake : ICrystaTaskService
     public Task<int> DeleteCrystaTaskCommentsAsync(List<string> syncIds)
     {
         if (syncIds == null || syncIds.Count == 0) return Task.FromResult(0);
-        var removed = _comments.RemoveAll(c =>
-            (c.Revision != null && syncIds.Contains(c.Revision)) ||
-            (c.ProviderTaskId != null && syncIds.Contains(c.ProviderTaskId)) ||
-            (c.Id != Guid.Empty && syncIds.Contains(c.Id.ToString())));
-        return Task.FromResult(removed);
+        int marked = 0;
+        foreach (var c in _comments)
+        {
+            if (
+                (c.Revision != null && syncIds.Contains(c.Revision)) ||
+                (c.ProviderTaskId != null && syncIds.Contains(c.ProviderTaskId)) ||
+                (c.Id != Guid.Empty && syncIds.Contains(c.Id.ToString()))
+            )
+            {
+                if (c.IsDeleted != true)
+                {
+                    c.IsDeleted = true;
+                    c.SyncStatus = CrystaSyncStatus.Deleted;
+                    marked++;
+                }
+            }
+        }
+        return Task.FromResult(marked);
     }
 
     public Task<int> DeleteCrystaTaskRevisionsAsync(List<string> syncIds)

--- a/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
+++ b/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
@@ -194,7 +194,17 @@ public class CrystaTaskServiceFake : ICrystaTaskService
         if (revisions == null) return Task.CompletedTask;
         foreach (var r in revisions)
         {
-            var existing = _revisions.FirstOrDefault(x => x.Id == r.Id || (!string.IsNullOrEmpty(x.Revision) && x.Revision == r.Revision));
+            var existing = _revisions.FirstOrDefault(x =>
+                x.Id == r.Id ||
+                (
+                    !string.IsNullOrEmpty(x.ProviderTaskId) &&
+                    !string.IsNullOrEmpty(r.ProviderTaskId) &&
+                    x.ProviderTaskId == r.ProviderTaskId &&
+                    !string.IsNullOrEmpty(x.Revision) &&
+                    !string.IsNullOrEmpty(r.Revision) &&
+                    x.Revision == r.Revision
+                )
+            );
             if (existing != null)
             {
                 var idx = _revisions.IndexOf(existing);

--- a/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
+++ b/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
@@ -1,0 +1,250 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CrystaLearn.Core.Models.Crysta;
+using CrystaLearn.Core.Services.Contracts;
+using CrystaLearn.Core.Services.Sync;
+
+namespace CrystaLearn.Core.Services;
+
+public class CrystaTaskServiceFake : ICrystaTaskService
+{
+    // In-memory stores for the fake implementation
+    private readonly List<CrystaTask> _tasks = new();
+    private readonly List<CrystaTaskComment> _comments = new();
+    private readonly List<CrystaTaskRevision> _revisions = new();
+    private readonly List<CrystaTaskUpdate> _updates = new();
+
+    private static Guid EnsureId(Guid id) => id == Guid.Empty ? Guid.NewGuid() : id;
+
+    public Task AddCrystaTaskCommentsAsync(List<CrystaTaskComment> comments)
+    {
+        if (comments == null) return Task.CompletedTask;
+        foreach (var c in comments)
+        {
+            c.Id = EnsureId(c.Id);
+            _comments.Add(c);
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task AddCrystaTaskRevisionsAsync(List<CrystaTaskRevision> revisions)
+    {
+        if (revisions == null) return Task.CompletedTask;
+        foreach (var r in revisions)
+        {
+            r.Id = EnsureId(r.Id);
+            _revisions.Add(r);
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task AddCrystaTasksAsync(List<CrystaTask> tasks)
+    {
+        if (tasks == null) return Task.CompletedTask;
+        foreach (var t in tasks)
+        {
+            t.Id = EnsureId(t.Id);
+            _tasks.Add(t);
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task AddCrystaTaskUpdatesAsync(List<CrystaTaskUpdate> updates)
+    {
+        if (updates == null) return Task.CompletedTask;
+        foreach (var u in updates)
+        {
+            u.Id = EnsureId(u.Id);
+            _updates.Add(u);
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task<int> DeleteCrystaTaskCommentsAsync(List<string> syncIds)
+    {
+        if (syncIds == null || syncIds.Count == 0) return Task.FromResult(0);
+        var removed = _comments.RemoveAll(c =>
+            (c.Revision != null && syncIds.Contains(c.Revision)) ||
+            (c.ProviderTaskId != null && syncIds.Contains(c.ProviderTaskId)) ||
+            (c.Id != Guid.Empty && syncIds.Contains(c.Id.ToString())));
+        return Task.FromResult(removed);
+    }
+
+    public Task<int> DeleteCrystaTaskRevisionsAsync(List<string> syncIds)
+    {
+        if (syncIds == null || syncIds.Count == 0) return Task.FromResult(0);
+        var removed = _revisions.RemoveAll(r =>
+            (r.Revision != null && syncIds.Contains(r.Revision)) ||
+            (r.ProviderTaskId != null && syncIds.Contains(r.ProviderTaskId)) ||
+            (r.Id != Guid.Empty && syncIds.Contains(r.Id.ToString())));
+        return Task.FromResult(removed);
+    }
+
+    public Task<int> DeleteCrystaTaskUpdatesAsync(List<string> syncIds)
+    {
+        if (syncIds == null || syncIds.Count == 0) return Task.FromResult(0);
+        var removed = _updates.RemoveAll(u =>
+            (u.Revision != null && syncIds.Contains(u.Revision)) ||
+            (u.ProviderTaskId != null && syncIds.Contains(u.ProviderTaskId)) ||
+            (u.Id != Guid.Empty && syncIds.Contains(u.Id.ToString())));
+        return Task.FromResult(removed);
+    }
+
+    public Task<List<string>> GetAllWorkItemSyncIdsAsync(string project)
+    {
+        var ids = _tasks
+            .Where(t => !string.IsNullOrEmpty(t.ProviderTaskId))
+            .Select(t => t.ProviderTaskId!)
+            .ToList();
+
+        // If project filtering is required and CrystaProgram contains project name, filter.
+        if (!string.IsNullOrEmpty(project))
+        {
+            ids = _tasks
+                .Where(t => t.CrystaProgram != null && string.Equals(t.CrystaProgram.ToString(), project, StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(t.ProviderTaskId))
+                .Select(t => t.ProviderTaskId!)
+                .ToList();
+        }
+
+        return Task.FromResult(ids);
+    }
+
+    public Task<List<SyncItem>> GetCommentsSyncItemsAsync(List<string> ids)
+    {
+        if (ids == null || ids.Count == 0) return Task.FromResult(new List<SyncItem>());
+        var found = _comments
+            .Where(c => (c.Revision != null && ids.Contains(c.Revision)) || (c.ProviderTaskId != null && ids.Contains(c.ProviderTaskId)) || (c.Id != Guid.Empty && ids.Contains(c.Id.ToString())))
+            .Select(c => new SyncItem { Id = c.Id })
+            .ToList();
+        return Task.FromResult(found);
+    }
+
+    public Task<List<SyncItem>> GetRevisionsSyncItemsAsync(List<string> ids)
+    {
+        if (ids == null || ids.Count == 0) return Task.FromResult(new List<SyncItem>());
+        var found = _revisions
+            .Where(r => (r.Revision != null && ids.Contains(r.Revision)) || (r.ProviderTaskId != null && ids.Contains(r.ProviderTaskId)) || (r.Id != Guid.Empty && ids.Contains(r.Id.ToString())))
+            .Select(r => new SyncItem { Id = r.Id })
+            .ToList();
+        return Task.FromResult(found);
+    }
+
+    public Task<List<SyncItem>> GetUpdatesSyncItemsAsync(List<string> ids)
+    {
+        if (ids == null || ids.Count == 0) return Task.FromResult(new List<SyncItem>());
+        var found = _updates
+            .Where(u => (u.Revision != null && ids.Contains(u.Revision)) || (u.ProviderTaskId != null && ids.Contains(u.ProviderTaskId)) || (u.Id != Guid.Empty && ids.Contains(u.Id.ToString())))
+            .Select(u => new SyncItem { Id = u.Id })
+            .ToList();
+        return Task.FromResult(found);
+    }
+
+    public Task<List<SyncItem>> GetWorkItemSyncItemsAsync(List<string> ids)
+    {
+        if (ids == null || ids.Count == 0) return Task.FromResult(new List<SyncItem>());
+        var found = _tasks
+            .Where(t => (t.ProviderTaskId != null && ids.Contains(t.ProviderTaskId)) || (t.Id != Guid.Empty && ids.Contains(t.Id.ToString())))
+            .Select(t => new SyncItem { Id = t.Id })
+            .ToList();
+        return Task.FromResult(found);
+    }
+
+    public Task<int> MarkCrystaTasksAsDeletedAsync(List<string> syncIds)
+    {
+        if (syncIds == null || syncIds.Count == 0) return Task.FromResult(0);
+        var matched = _tasks.Where(t => (t.ProviderTaskId != null && syncIds.Contains(t.ProviderTaskId)) || (t.Id != Guid.Empty && syncIds.Contains(t.Id.ToString()))).ToList();
+        foreach (var t in matched)
+        {
+            t.IsDeleted = true;
+        }
+        return Task.FromResult(matched.Count);
+    }
+
+    public Task UpdateCrystaTaskCommentsAsync(List<CrystaTaskComment> comments)
+    {
+        if (comments == null) return Task.CompletedTask;
+        foreach (var c in comments)
+        {
+            var existing = _comments.FirstOrDefault(x => x.Id == c.Id || (!string.IsNullOrEmpty(x.Revision) && x.Revision == c.Revision));
+            if (existing != null)
+            {
+                // naive replace of reference properties
+                var idx = _comments.IndexOf(existing);
+                c.Id = existing.Id;
+                _comments[idx] = c;
+            }
+            else
+            {
+                c.Id = EnsureId(c.Id);
+                _comments.Add(c);
+            }
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateCrystaTaskRevisionsAsync(List<CrystaTaskRevision> revisions)
+    {
+        if (revisions == null) return Task.CompletedTask;
+        foreach (var r in revisions)
+        {
+            var existing = _revisions.FirstOrDefault(x => x.Id == r.Id || (!string.IsNullOrEmpty(x.Revision) && x.Revision == r.Revision));
+            if (existing != null)
+            {
+                var idx = _revisions.IndexOf(existing);
+                r.Id = existing.Id;
+                _revisions[idx] = r;
+            }
+            else
+            {
+                r.Id = EnsureId(r.Id);
+                _revisions.Add(r);
+            }
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateCrystaTasksAsync(List<CrystaTask> tasks)
+    {
+        if (tasks == null) return Task.CompletedTask;
+        foreach (var t in tasks)
+        {
+            var existing = _tasks.FirstOrDefault(x => x.Id == t.Id || (!string.IsNullOrEmpty(x.ProviderTaskId) && x.ProviderTaskId == t.ProviderTaskId));
+            if (existing != null)
+            {
+                var idx = _tasks.IndexOf(existing);
+                t.Id = existing.Id;
+                _tasks[idx] = t;
+            }
+            else
+            {
+                t.Id = EnsureId(t.Id);
+                _tasks.Add(t);
+            }
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateCrystaTaskUpdatesAsync(List<CrystaTaskUpdate> updates)
+    {
+        if (updates == null) return Task.CompletedTask;
+        foreach (var u in updates)
+        {
+            var existing = _updates.FirstOrDefault(x => x.Id == u.Id || (!string.IsNullOrEmpty(x.Revision) && x.Revision == u.Revision));
+            if (existing != null)
+            {
+                var idx = _updates.IndexOf(existing);
+                u.Id = existing.Id;
+                _updates[idx] = u;
+            }
+            else
+            {
+                u.Id = EnsureId(u.Id);
+                _updates.Add(u);
+            }
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
+++ b/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using CrystaLearn.Core.Models.Crysta;
 using CrystaLearn.Core.Services.Contracts;

--- a/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
+++ b/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
@@ -140,17 +140,7 @@ public class CrystaTaskServiceFake : ICrystaTaskService
         if (ids == null || ids.Count == 0) return Task.FromResult(new List<SyncItem>());
         var found = _tasks
             .Where(t => ids.Contains(t.WorkItemSyncInfo.SyncId ?? ""))
-            .Select(t => new SyncItem
-            {
-                Id = t.Id,
-                SyncInfo = t.WorkItemSyncInfo == null
-                    ? null
-                    : new SyncInfo
-                    {
-                        SyncId = t.WorkItemSyncInfo.SyncId,
-                        ContentHash = t.WorkItemSyncInfo.ContentHash
-                    }
-            })
+            .Select(t => new SyncItem { Id = t.Id, SyncInfo = t.WorkItemSyncInfo })
             .ToList();
         return Task.FromResult(found);
     }

--- a/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
+++ b/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
@@ -90,9 +90,13 @@ public class CrystaTaskServiceFake : ICrystaTaskService
     {
         if (syncIds == null || syncIds.Count == 0) return Task.FromResult(0);
         var removed = _revisions.RemoveAll(r =>
-            (r.Revision != null && syncIds.Contains(r.Revision)) ||
-            (r.ProviderTaskId != null && syncIds.Contains(r.ProviderTaskId)) ||
-            (r.Id != Guid.Empty && syncIds.Contains(r.Id.ToString())));
+        {
+            // Compose the composite key as in the real service: ProviderTaskId-Revision
+            var providerTaskId = r.ProviderTaskId ?? "";
+            var revision = r.Revision ?? "";
+            var compositeKey = $"{providerTaskId}-{revision}";
+            return syncIds.Contains(compositeKey);
+        });
         return Task.FromResult(removed);
     }
 

--- a/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
+++ b/src/Core/CrystaLearn.Core/Services/CrystaTaskServiceFake.cs
@@ -87,9 +87,7 @@ public class CrystaTaskServiceFake : ICrystaTaskService
     {
         if (syncIds == null || syncIds.Count == 0) return Task.FromResult(0);
         var removed = _updates.RemoveAll(u =>
-            (u.Revision != null && syncIds.Contains(u.Revision)) ||
-            (u.ProviderTaskId != null && syncIds.Contains(u.ProviderTaskId)) ||
-            (u.Id != Guid.Empty && syncIds.Contains(u.Id.ToString())));
+            u.SyncInfo != null && !string.IsNullOrEmpty(u.SyncInfo.SyncId) && syncIds.Contains(u.SyncInfo.SyncId));
         return Task.FromResult(removed);
     }
 

--- a/src/Core/CrystaLearn.Core/Services/Sync/AzureBoardSyncService.cs
+++ b/src/Core/CrystaLearn.Core/Services/Sync/AzureBoardSyncService.cs
@@ -12,7 +12,7 @@ public partial class AzureBoardSyncService : IAzureBoardSyncService
 {
     [AutoInject] private IAzureBoardService AzureBoardService { get; set; } = default!;
     [AutoInject] private IConfiguration Configuration { get; set; } = default!;
-    [AutoInject] private ICrystaTaskRepository CrystaTaskRepository { get; set; } = default!;
+    [AutoInject] private ICrystaTaskService CrystaTaskService { get; set; } = default!;
     [AutoInject] private ICrystaProgramSyncModuleService CrystaProgramSyncModuleRepository { get; set; } = default!;
 
     public async Task<SyncResult> SyncAsync(CrystaProgramSyncModule module, List<int>? workItemIds = null)
@@ -104,7 +104,7 @@ public partial class AzureBoardSyncService : IAzureBoardSyncService
                 .ToList();
 
             if (tasksToUpdate.Count > 0)
-                await CrystaTaskRepository.UpdateCrystaTasksAsync(tasksToUpdate);
+                await CrystaTaskService.UpdateCrystaTasksAsync(tasksToUpdate);
 
 
             // Aggregate results
@@ -178,7 +178,7 @@ public partial class AzureBoardSyncService : IAzureBoardSyncService
 
         // Preload mapping of WorkItem SyncId -> CrystaTask.Id for existing tasks (used when task.Id == Guid.Empty)
         var taskSyncIds = tasks.Select(t => t.WorkItemSyncInfo.SyncId ?? "").Where(s => !string.IsNullOrEmpty(s)).Distinct().ToList();
-        var workItemSyncItems = taskSyncIds.Count > 0 ? await CrystaTaskRepository.GetWorkItemSyncItemsAsync(taskSyncIds) : new List<SyncItem>();
+        var workItemSyncItems = taskSyncIds.Count > 0 ? await CrystaTaskService.GetWorkItemSyncItemsAsync(taskSyncIds) : new List<SyncItem>();
         var syncIdToGuidMap = workItemSyncItems.Where(s => s.SyncInfo != null && s.Id.HasValue)
             .ToDictionary(s => s.SyncInfo.SyncId ?? string.Empty, s => s.Id.Value, StringComparer.OrdinalIgnoreCase);
 
@@ -257,7 +257,7 @@ public partial class AzureBoardSyncService : IAzureBoardSyncService
             .ToList();
 
         var ids = updateSyncItems.Select(u => u.SyncInfo.SyncId ?? "").Where(id => !string.IsNullOrEmpty(id)).ToList();
-        var existingUpdateSyncItems = await CrystaTaskRepository.GetUpdatesSyncItemsAsync(ids);
+        var existingUpdateSyncItems = await CrystaTaskService.GetUpdatesSyncItemsAsync(ids);
 
         var toAddList = updateSyncItems
                         .Where(board => existingUpdateSyncItems.All(existing => board.SyncInfo.SyncId != existing.SyncInfo.SyncId))
@@ -281,10 +281,10 @@ public partial class AzureBoardSyncService : IAzureBoardSyncService
         var toUpdate = toAddOrUpdate.Where(u => toUpdateList.Any(s => s.SyncInfo.SyncId == u.SyncInfo.SyncId)).ToList();
 
         if (toAdd.Count > 0)
-            await CrystaTaskRepository.AddCrystaTaskUpdatesAsync(toAdd);
+            await CrystaTaskService.AddCrystaTaskUpdatesAsync(toAdd);
 
         if (toUpdate.Count > 0)
-            await CrystaTaskRepository.UpdateCrystaTaskUpdatesAsync(toUpdate);
+            await CrystaTaskService.UpdateCrystaTaskUpdatesAsync(toUpdate);
 
         return new SyncResult
         {
@@ -306,7 +306,7 @@ public partial class AzureBoardSyncService : IAzureBoardSyncService
 
         // Preload mapping of WorkItem SyncId -> CrystaTask.Id for existing tasks
         var taskSyncIds = tasks.Select(t => t.WorkItemSyncInfo.SyncId ?? "").Where(s => !string.IsNullOrEmpty(s)).Distinct().ToList();
-        var workItemSyncItems = taskSyncIds.Count > 0 ? await CrystaTaskRepository.GetWorkItemSyncItemsAsync(taskSyncIds) : new List<SyncItem>();
+        var workItemSyncItems = taskSyncIds.Count > 0 ? await CrystaTaskService.GetWorkItemSyncItemsAsync(taskSyncIds) : new List<SyncItem>();
         var syncIdToGuidMap = workItemSyncItems.Where(s => s.SyncInfo != null && s.Id.HasValue)
             .ToDictionary(s => s.SyncInfo.SyncId ?? string.Empty, s => s.Id.Value, StringComparer.OrdinalIgnoreCase);
 
@@ -376,7 +376,7 @@ public partial class AzureBoardSyncService : IAzureBoardSyncService
             .ToList();
 
         var ids = commentSyncItems.Select(c => c.SyncInfo.SyncId ?? "").Where(id => !string.IsNullOrEmpty(id)).ToList();
-        var existingCommentSyncItems = await CrystaTaskRepository.GetCommentsSyncItemsAsync(ids);
+        var existingCommentSyncItems = await CrystaTaskService.GetCommentsSyncItemsAsync(ids);
 
         var toAddList = commentSyncItems
                         .Where(board => existingCommentSyncItems.All(existing => board.SyncInfo.SyncId != existing.SyncInfo.SyncId))
@@ -399,10 +399,10 @@ public partial class AzureBoardSyncService : IAzureBoardSyncService
         var toUpdate = toAddOrUpdate.Where(c => toUpdateList.Any(s => s.SyncInfo.SyncId == c.SyncInfo.SyncId)).ToList();
 
         if (toAdd.Count > 0)
-            await CrystaTaskRepository.AddCrystaTaskCommentsAsync(toAdd);
+            await CrystaTaskService.AddCrystaTaskCommentsAsync(toAdd);
 
         if (toUpdate.Count > 0)
-            await CrystaTaskRepository.UpdateCrystaTaskCommentsAsync(toUpdate);
+            await CrystaTaskService.UpdateCrystaTaskCommentsAsync(toUpdate);
 
         return new SyncResult
         {
@@ -425,7 +425,7 @@ public partial class AzureBoardSyncService : IAzureBoardSyncService
 
         // Preload mapping of WorkItem SyncId -> CrystaTask.Id for existing tasks
         var taskSyncIds = tasks.Select(t => t.WorkItemSyncInfo.SyncId ?? "").Where(s => !string.IsNullOrEmpty(s)).Distinct().ToList();
-        var workItemSyncItems = taskSyncIds.Count > 0 ? await CrystaTaskRepository.GetWorkItemSyncItemsAsync(taskSyncIds) : new List<SyncItem>();
+        var workItemSyncItems = taskSyncIds.Count > 0 ? await CrystaTaskService.GetWorkItemSyncItemsAsync(taskSyncIds) : new List<SyncItem>();
         var syncIdToGuidMap = workItemSyncItems.Where(s => s.SyncInfo != null && s.Id.HasValue)
             .ToDictionary(s => s.SyncInfo.SyncId ?? string.Empty, s => s.Id.Value, StringComparer.OrdinalIgnoreCase);
 
@@ -506,7 +506,7 @@ public partial class AzureBoardSyncService : IAzureBoardSyncService
             .ToList();
 
         var ids = revisionSyncItems.Select(r => r.SyncInfo.SyncId ?? "").Where(id => !string.IsNullOrEmpty(id)).ToList();
-        var existingRevisionSyncItems = await CrystaTaskRepository.GetRevisionsSyncItemsAsync(ids);
+        var existingRevisionSyncItems = await CrystaTaskService.GetRevisionsSyncItemsAsync(ids);
 
         var toAddList = revisionSyncItems
                         .Where(board => existingRevisionSyncItems.All(existing => board.SyncInfo.SyncId != existing.SyncInfo.SyncId))
@@ -529,10 +529,10 @@ public partial class AzureBoardSyncService : IAzureBoardSyncService
         var toUpdate = toAddOrUpdate.Where(r => toUpdateList.Any(s => s.SyncInfo.SyncId == r.WorkItemSyncInfo.SyncId)).ToList();
 
         if (toAdd.Count > 0)
-            await CrystaTaskRepository.AddCrystaTaskRevisionsAsync(toAdd);
+            await CrystaTaskService.AddCrystaTaskRevisionsAsync(toAdd);
 
         if (toUpdate.Count > 0)
-            await CrystaTaskRepository.UpdateCrystaTaskRevisionsAsync(toUpdate);
+            await CrystaTaskService.UpdateCrystaTaskRevisionsAsync(toUpdate);
 
         return new SyncResult
         {
@@ -559,7 +559,7 @@ public partial class AzureBoardSyncService : IAzureBoardSyncService
 
         var ids = boardSyncItems.Select(wi => wi.SyncInfo.SyncId ?? "").Where(id => !string.IsNullOrEmpty(id)).ToList();
 
-        var existingWorkItemSyncItems = await CrystaTaskRepository.GetWorkItemSyncItemsAsync(ids);
+        var existingWorkItemSyncItems = await CrystaTaskService.GetWorkItemSyncItemsAsync(ids);
 
         var toAddList = boardSyncItems
                         .Where(board => existingWorkItemSyncItems.All(existing => board.SyncInfo.SyncId != existing.SyncInfo.SyncId))
@@ -630,7 +630,7 @@ public partial class AzureBoardSyncService : IAzureBoardSyncService
         if (missingParentSyncIds.Count > 0)
         {
             // Try to load missing parents from DB in one call
-            var parentSyncItems = await CrystaTaskRepository.GetWorkItemSyncItemsAsync(missingParentSyncIds.ToList());
+            var parentSyncItems = await CrystaTaskService.GetWorkItemSyncItemsAsync(missingParentSyncIds.ToList());
             foreach (var p in parentSyncItems)
             {
                 var sid = p.SyncInfo?.SyncId;
@@ -655,10 +655,10 @@ public partial class AzureBoardSyncService : IAzureBoardSyncService
         }
 
         if (toAdd.Count > 0)
-            await CrystaTaskRepository.AddCrystaTasksAsync(toAdd);
+            await CrystaTaskService.AddCrystaTasksAsync(toAdd);
 
         if (toUpdate.Count > 0)
-            await CrystaTaskRepository.UpdateCrystaTasksAsync(toUpdate);
+            await CrystaTaskService.UpdateCrystaTasksAsync(toUpdate);
 
         // Build combined list: existing + newly added (toAddList)
         //var combined = new List<SyncItem>(existingWorkItemSyncItems.Count + toAddList.Count);


### PR DESCRIPTION
Replaced ICrystaTaskRepository with ICrystaTaskService across the codebase, updating all usages and DI registrations. Introduced CrystaTaskServiceFake for in-memory testing and updated AzureBoardSyncServiceTests to use fakes. Adjusted CrystaProgramSyncModuleServiceFake to accept configuration. Added src.sln for Visual Studio project structure.